### PR TITLE
chore: mock maken voor publicaties op backend

### DIFF
--- a/ODPC.Server/Features/Publicaties/Publicatie.cs
+++ b/ODPC.Server/Features/Publicaties/Publicatie.cs
@@ -1,0 +1,12 @@
+﻿namespace ODPC.Features.Publicaties
+{
+    public class Publicatie
+    {
+        public Guid Uuid { get; set; }
+        public string? OfficieleTitel { get; set; }
+        public string? VerkorteTitel { get; set; }
+        public string? Omschrijving { get; set; }
+        public DateOnly Creatiedatum { get; set; }
+        public string? Status { get; set; }
+    }
+}

--- a/ODPC.Server/Features/Publicaties/PublicatieBijwerken/PublicatieBijwerkenController.cs
+++ b/ODPC.Server/Features/Publicaties/PublicatieBijwerken/PublicatieBijwerkenController.cs
@@ -1,0 +1,15 @@
+﻿using Microsoft.AspNetCore.Mvc;
+
+namespace ODPC.Features.Publicaties.PublicatieBijwerken
+{
+    [ApiController]
+    public class PublicatieBijwerkenController : ControllerBase
+    {
+        [HttpPut("api/v1/publicaties/{uuid}")]
+        public IActionResult Put(Guid uuid, Publicatie publicatie)
+        {
+            PublicatiesMock.Publicaties[uuid] = publicatie;
+            return Ok(publicatie);
+        }
+    }
+}

--- a/ODPC.Server/Features/Publicaties/PublicatieDetails/PublicatieDetailsController.cs
+++ b/ODPC.Server/Features/Publicaties/PublicatieDetails/PublicatieDetailsController.cs
@@ -1,0 +1,16 @@
+﻿using Microsoft.AspNetCore.Mvc;
+
+namespace ODPC.Features.Publicaties.PublicatieDetails
+{
+    [ApiController]
+    public class PublicatieDetailsController : ControllerBase
+    {
+        [HttpGet("api/v1/publicaties/{uuid}")]
+        public IActionResult Get(Guid uuid)
+        {
+            return PublicatiesMock.Publicaties.TryGetValue(uuid, out var publicatie)
+                ? Ok(publicatie)
+                : NotFound();
+        }
+    }
+}

--- a/ODPC.Server/Features/Publicaties/PublicatieRegistreren/PublicatieRegistrerenController.cs
+++ b/ODPC.Server/Features/Publicaties/PublicatieRegistreren/PublicatieRegistrerenController.cs
@@ -1,0 +1,17 @@
+﻿using Microsoft.AspNetCore.Mvc;
+
+namespace ODPC.Features.Publicaties.PublicatieRegistreren
+{
+    [ApiController]
+    public class PublicatieRegistrerenController : ControllerBase
+    {
+        [HttpPost("api/v1/publicaties")]
+        public IActionResult Post(Publicatie publicatie)
+        {
+            publicatie.Uuid = Guid.NewGuid();
+            publicatie.Creatiedatum = DateOnly.FromDateTime(DateTime.Now);
+            PublicatiesMock.Publicaties[publicatie.Uuid] = publicatie;
+            return Ok(publicatie);
+        }
+    }
+}

--- a/ODPC.Server/Features/Publicaties/PublicatiesMock.cs
+++ b/ODPC.Server/Features/Publicaties/PublicatiesMock.cs
@@ -1,25 +1,11 @@
-﻿using Microsoft.AspNetCore.Mvc;
-
-namespace ODPC.Features.Publicaties
+﻿namespace ODPC.Features.Publicaties
 {
-    public class Publicatie
+    public static class PublicatiesMock
     {
-        public Guid Uuid { get; set; }
-        public string? OfficieleTitel { get; set; }
-        public string? VerkorteTitel { get; set; }
-        public string? Omschrijving { get; set; }
-        public DateOnly Creatiedatum { get; set; }
-        public string? Status { get; set; }
-    }
-
-    [ApiController]
-    [Route("api/v1/publicaties")]
-    public class PublicatiesMock: ControllerBase
-    {
-        private static readonly Dictionary<Guid, Publicatie> s_publicaties = new Publicatie[] 
+        public static readonly Dictionary<Guid, Publicatie> Publicaties = new Publicatie[]
         {
-            new() 
-            { 
+            new()
+            {
                 Uuid = Guid.NewGuid(),
                 OfficieleTitel = "Openbaarheid en Verantwoording: De Impact van de Wet open overheid op Bestuurlijke Transparantie",
                 VerkorteTitel = "Openbaarheid en Verantwoording",
@@ -34,37 +20,6 @@ namespace ODPC.Features.Publicaties
                 Omschrijving = "",
                 Creatiedatum = new DateOnly(2024, 05, 02)
             }
-        }.ToDictionary(x=> x.Uuid);
-
-        [HttpGet]
-        public IActionResult AllPublicaties() => Ok(s_publicaties.Values);
-
-        [HttpGet("{uuid}")]
-        public IActionResult Single(Guid uuid) => s_publicaties.TryGetValue(uuid, out var publicatie) 
-            ? Ok(publicatie) 
-            : NotFound();
-
-        [HttpPost]
-        public IActionResult Post(Publicatie publicatie)
-        {
-            publicatie.Uuid = Guid.NewGuid();
-            publicatie.Creatiedatum = DateOnly.FromDateTime(DateTime.Now);
-            s_publicaties[publicatie.Uuid] = publicatie;
-            return Ok(publicatie);
-        }
-
-        [HttpPut("{uuid}")]
-        public IActionResult Put(Guid uuid, Publicatie publicatie)
-        {
-            s_publicaties[uuid] = publicatie;
-            return Ok(publicatie);
-        }
-
-        [HttpDelete("{uuid}")]
-        public IActionResult Delete(Guid uuid) 
-        {
-            s_publicaties.Remove(uuid);
-            return NoContent();
-        }
+        }.ToDictionary(x => x.Uuid);
     }
 }

--- a/ODPC.Server/Features/Publicaties/PublicatiesMock.cs
+++ b/ODPC.Server/Features/Publicaties/PublicatiesMock.cs
@@ -1,0 +1,70 @@
+﻿using Microsoft.AspNetCore.Mvc;
+
+namespace ODPC.Features.Publicaties
+{
+    public class Publicatie
+    {
+        public Guid Uuid { get; set; }
+        public string? OfficieleTitel { get; set; }
+        public string? VerkorteTitel { get; set; }
+        public string? Omschrijving { get; set; }
+        public DateOnly Creatiedatum { get; set; }
+        public string? Status { get; set; }
+    }
+
+    [ApiController]
+    [Route("api/v1/publicaties")]
+    public class PublicatiesMock: ControllerBase
+    {
+        private static readonly Dictionary<Guid, Publicatie> s_publicaties = new Publicatie[] 
+        {
+            new() 
+            { 
+                Uuid = Guid.NewGuid(),
+                OfficieleTitel = "Openbaarheid en Verantwoording: De Impact van de Wet open overheid op Bestuurlijke Transparantie",
+                VerkorteTitel = "Openbaarheid en Verantwoording",
+                Omschrijving = "",
+                Creatiedatum = new DateOnly(2024, 08, 24)
+            },
+            new()
+            {
+                Uuid = Guid.NewGuid(),
+                OfficieleTitel = "Inzicht voor Iedereen: Toepassing en Resultaten van de Wet open overheid",
+                VerkorteTitel = "Inzicht voor Iedereen",
+                Omschrijving = "",
+                Creatiedatum = new DateOnly(2024, 05, 02)
+            }
+        }.ToDictionary(x=> x.Uuid);
+
+        [HttpGet]
+        public IActionResult AllPublicaties() => Ok(s_publicaties.Values);
+
+        [HttpGet("{uuid}")]
+        public IActionResult Single(Guid uuid) => s_publicaties.TryGetValue(uuid, out var publicatie) 
+            ? Ok(publicatie) 
+            : NotFound();
+
+        [HttpPost]
+        public IActionResult Post(Publicatie publicatie)
+        {
+            publicatie.Uuid = Guid.NewGuid();
+            publicatie.Creatiedatum = DateOnly.FromDateTime(DateTime.Now);
+            s_publicaties[publicatie.Uuid] = publicatie;
+            return Ok(publicatie);
+        }
+
+        [HttpPut("{uuid}")]
+        public IActionResult Put(Guid uuid, Publicatie publicatie)
+        {
+            s_publicaties[uuid] = publicatie;
+            return Ok(publicatie);
+        }
+
+        [HttpDelete("{uuid}")]
+        public IActionResult Delete(Guid uuid) 
+        {
+            s_publicaties.Remove(uuid);
+            return NoContent();
+        }
+    }
+}

--- a/ODPC.Server/Features/Publicaties/PublicatiesOverzicht/PublicatiesOverzichtController.cs
+++ b/ODPC.Server/Features/Publicaties/PublicatiesOverzicht/PublicatiesOverzichtController.cs
@@ -1,0 +1,14 @@
+﻿using Microsoft.AspNetCore.Mvc;
+
+namespace ODPC.Features.Publicaties.PublicatiesOverzicht
+{
+    [ApiController]
+    public class PublicatiesOverzichtController : ControllerBase
+    {
+        [HttpGet("api/v1/publicaties")]
+        public IActionResult Get()
+        {
+            return Ok(PublicatiesMock.Publicaties.Values.OrderByDescending(x => x.Creatiedatum));
+        }
+    }
+}

--- a/odpc.client/src/features/publicatie/PublicatieDetails.vue
+++ b/odpc.client/src/features/publicatie/PublicatieDetails.vue
@@ -62,7 +62,7 @@ const publicatie = ref<Publicatie | null>({
 });
 
 const { data, isFetching, error, post, put, execute } = useFetchApi(
-  () => `/api-mock/publicaties${props.id ? "/" + props.id : ""}`,
+  () => `/api/v1/publicaties${props.id ? "/" + props.id : ""}`,
   { immediate: false }
 ).json<Publicatie>();
 

--- a/odpc.client/src/features/publicatie/PublicatiesOverview.vue
+++ b/odpc.client/src/features/publicatie/PublicatiesOverview.vue
@@ -31,7 +31,7 @@ import SimpleSpinner from "@/components/SimpleSpinner.vue";
 import AlertInline from "@/components/AlertInline.vue";
 import type { Publicatie } from "./types";
 
-const { data, isFetching, error } = useFetchApi("/api-mock/publicaties").json<Publicatie[]>();
+const { data, isFetching, error } = useFetchApi("/api/v1/publicaties").json<Publicatie[]>();
 </script>
 
 <style lang="scss" scoped>


### PR DESCRIPTION
We gebruiken een mock server voor vite, maar die werkt alleen tijdens local development. Daarom voegen we een mock toe voor Publciaties op de backend, totdat die functionaliteit gerealiseerd is in de Registratiecomponent.